### PR TITLE
#1 liveビューの表示改善（フライヤー全体表示 / Coming Soon / 公演カード見直し）

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -639,34 +639,108 @@ header.nav-open .nav-toggle-icon span:nth-child(3) {
   flex: 0 0 clamp(92px, 22vw, 128px);
   border-radius: var(--radius-sm);
   border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.75);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(245, 245, 245, 0.9));
   overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .live-flyer img {
   width: 100%;
-  height: 100%;
-  aspect-ratio: 1 / 1;
-  object-fit: cover;
+  height: auto;
+  display: block;
+  object-fit: contain;
 }
 
 .live-flyer-placeholder {
   width: 100%;
   height: 100%;
-  min-height: 100px;
+  min-height: 220px;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  color: var(--ink-muted);
-  font-size: 0.7rem;
-  letter-spacing: 0.12em;
+  color: var(--accent);
+  font-size: 0.88rem;
+  letter-spacing: 0.18em;
+  font-weight: 700;
   text-transform: uppercase;
+  background:
+    radial-gradient(circle at top, rgba(191, 85, 77, 0.12), transparent 56%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(245, 245, 245, 0.92));
 }
 
 .live-event.with-flyer .live-info {
   min-width: 0;
   display: flex;
   flex-direction: column;
+  justify-content: center;
+}
+
+.live-event.is-featured {
+  display: block;
+  padding: 18px;
+  overflow: hidden;
+}
+
+.live-event.is-featured .live-flyer {
+  width: 100%;
+  flex-basis: auto;
+  min-height: 240px;
+}
+
+.live-event.is-featured .live-info {
+  margin-top: 16px;
+  padding-right: 56px;
+  gap: 10px;
+}
+
+.live-event.is-featured .live-meta {
+  gap: 8px 12px;
+}
+
+.live-event.is-featured .live-date {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: rgba(191, 85, 77, 0.12);
+  color: var(--accent);
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.live-event.is-featured .live-venue {
+  width: 100%;
+  font-style: normal;
+  font-size: 1.08rem;
+  color: var(--ink);
+}
+
+.live-event.is-featured .live-title {
+  font-size: 1.08rem;
+  line-height: 1.5;
+}
+
+.live-event.is-featured .live-description {
+  font-size: 0.94rem;
+  line-height: 1.8;
+}
+
+.live-event.is-featured .live-chevron {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 38px;
+  height: 38px;
+  border-radius: 999px;
+  border: 1px solid rgba(191, 85, 77, 0.18);
+  background: rgba(255, 255, 255, 0.9);
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
 }
 
@@ -1249,6 +1323,25 @@ footer p {
     flex-basis: 96px;
   }
 
+  .live-event.is-featured {
+    padding: 14px;
+  }
+
+  .live-event.is-featured .live-flyer {
+    width: 100%;
+    min-height: 180px;
+  }
+
+  .live-event.is-featured .live-info {
+    margin-top: 14px;
+    padding-right: 0;
+  }
+
+  .live-event.is-featured .live-chevron {
+    top: 14px;
+    right: 14px;
+  }
+
   .profile-links .application-link {
     width: 80%;
     max-width: 320px;
@@ -1263,4 +1356,3 @@ footer p {
     scroll-behavior: auto !important;
   }
 }
-

--- a/assets/js/site-content.js
+++ b/assets/js/site-content.js
@@ -200,6 +200,7 @@
     if (events.length === 0) return;
     const config = options && typeof options === "object" ? options : {};
     const showFlyer = Boolean(config.showFlyer);
+    const featured = Boolean(config.featured);
     const detailHrefFactory = typeof config.detailHrefFactory === "function" ? config.detailHrefFactory : null;
 
     container.innerHTML = events
@@ -209,6 +210,14 @@
         const date = String(item.date || "").trim();
         const venue = String(item.venue || "").trim();
         const title = String(item.title || "").trim();
+        const description = String(item.description || "")
+          .replace(/<br\s*\/?>/gi, "\n")
+          .replace(/\r\n/g, "\n")
+          .split("\n")
+          .map((line) => line.trim())
+          .filter(Boolean)
+          .slice(0, 2)
+          .join("\n");
         const image = resolveImageSrc(item.image || "", version);
         const detailHref = detailHrefFactory
           ? detailHrefFactory(item, liveId)
@@ -217,9 +226,10 @@
             : `${prefix}live/detail/`;
         const imageAlt = [title, date, venue].filter(Boolean).join(" / ") || "live flyer";
         const flyerClass = showFlyer ? " with-flyer" : "";
+        const featuredClass = featured ? " is-featured" : "";
 
         return `
-          <a class="live-event${flyerClass}" href="${escapeHtml(detailHref)}">
+          <a class="live-event${flyerClass}${featuredClass}" href="${escapeHtml(detailHref)}">
             ${
               showFlyer
                 ? `
@@ -227,7 +237,7 @@
                 ${
                   image
                     ? `<img src="${escapeHtml(image)}" alt="${escapeHtml(imageAlt)}" loading="lazy">`
-                    : `<div class="live-flyer-placeholder" aria-hidden="true">flyer</div>`
+                    : `<div class="live-flyer-placeholder" aria-hidden="true">Coming Soon</div>`
                 }
               </div>
             `
@@ -239,6 +249,7 @@
                 <span class="live-venue">${escapeHtml(venue)}</span>
               </div>
               ${title ? `<div class="live-title">${escapeHtml(title)}</div>` : ""}
+              ${featured && description ? `<div class="live-description">${escapeHtml(description).replace(/\n/g, "<br>")}</div>` : ""}
             </div>
             <span class="live-chevron" aria-hidden="true">›</span>
           </a>
@@ -273,7 +284,7 @@
     const safeDesc = escapeHtml(String(live.description || "").replace(/<br\s*\/?>/gi, "\n")).replace(/\n/g, "<br>");
     body.innerHTML = `
       <div style="display:flex; gap: 14px; align-items: flex-start; flex-wrap: wrap;">
-        ${image ? `<img src="${escapeHtml(image)}" alt="" style="width: 160px; height: 160px; object-fit: cover; border-radius: 14px; border: 1px solid var(--line); background: rgba(255,255,255,0.7);">` : ""}
+        ${image ? `<img src="${escapeHtml(image)}" alt="" style="width: min(220px, 100%); max-height: min(70vh, 520px); object-fit: contain; border-radius: 14px; border: 1px solid var(--line); background: linear-gradient(180deg, rgba(255,255,255,0.96), rgba(245,245,245,0.92)); padding: 8px;">` : `<div class="live-flyer-placeholder" style="width: min(220px, 100%); min-height: min(70vh, 520px); border-radius: 14px; border: 1px solid var(--line);">Coming Soon</div>`}
         <div style="flex: 1; min-width: 240px;">
           <div style="font-family: var(--font-display); font-size: 1.05rem; letter-spacing: 0.08em;">${escapeHtml(heading)}</div>
           ${safeDesc ? `<div style="margin-top: 10px; color: var(--ink-muted); line-height: 1.8;">${safeDesc}</div>` : ""}
@@ -350,7 +361,10 @@
     const upcomingEvents = sortUpcomingLives(live.upcoming || []);
     const pastEvents = sortPastLives(live.past || []);
 
-    renderLiveEvents(document.getElementById("live-upcoming-events"), upcomingEvents, version, { showFlyer: true });
+    renderLiveEvents(document.getElementById("live-upcoming-events"), upcomingEvents, version, {
+      showFlyer: true,
+      featured: true,
+    });
     renderLiveEvents(document.getElementById("live-past-events"), pastEvents.slice(0, LIVE_PAST_PREVIEW_LIMIT), version, { showFlyer: false });
 
     const pastHeading = document.getElementById("live-past-heading");
@@ -398,6 +412,7 @@
     const titleEl = document.getElementById("live-detail-title");
     const headingEl = document.getElementById("live-detail-heading");
     const imgEl = document.getElementById("live-detail-image");
+    const placeholderEl = document.getElementById("live-detail-placeholder");
     const descEl = document.getElementById("live-detail-description");
     const ticketEl = document.getElementById("live-detail-ticket-link");
     const backEl = document.getElementById("live-detail-back-link");
@@ -443,17 +458,19 @@
     const venue = String(live.venue || "").trim();
     const heading = `${date} ${venue}`.trim();
 
-    if (titleEl) titleEl.textContent = liveTitle ? liveTitle : "live detail";
+    if (titleEl) titleEl.textContent = liveTitle ? liveTitle : "Coming Soon";
     if (headingEl) headingEl.textContent = heading;
 
     const image = resolveImageSrc(live.image || "", version);
     if (imgEl) {
       if (image) {
-        imgEl.src = escapeHtml(image);
+        imgEl.src = image;
         imgEl.style.display = "";
+        if (placeholderEl) placeholderEl.style.display = "none";
       } else {
         imgEl.removeAttribute("src");
         imgEl.style.display = "none";
+        if (placeholderEl) placeholderEl.style.display = "";
       }
     }
 
@@ -618,3 +635,4 @@
 
   boot();
 })();
+

--- a/live/detail/index.html
+++ b/live/detail/index.html
@@ -50,7 +50,7 @@
         <div id="live-detail-notfound" style="display:none; margin-top: 18px; padding: 14px; border: 1px solid var(--line); border-radius: var(--radius-md); background: rgba(255,255,255,0.7);"></div>
 
         <div id="live-detail-single" style="margin-top: 18px; display:flex; gap: 18px; align-items:flex-start; flex-wrap: wrap;">
-          <img id="live-detail-image" alt="" style="width: min(360px, 100%); aspect-ratio: 1/1; object-fit: cover; border-radius: var(--radius-md); border: 1px solid var(--line); background: rgba(255,255,255,0.7);" />
+          <div id="live-detail-visual" style="width: min(420px, 100%); align-self: flex-start;"><img id="live-detail-image" alt="" style="width: 100%; max-height: min(74vh, 760px); object-fit: contain; border-radius: var(--radius-md); border: 1px solid var(--line); background: linear-gradient(180deg, rgba(255,255,255,0.96), rgba(245,245,245,0.92)); padding: 10px; display:none;" /><div id="live-detail-placeholder" class="live-flyer-placeholder" style="width: 100%; min-height: min(74vh, 760px); border-radius: var(--radius-md); border: 1px solid var(--line); display:none;">Coming Soon</div></div>
 
           <div style="flex: 1; min-width: 240px;">
             <div id="live-detail-title" style="font-family: var(--font-display); font-size: 1.1rem; letter-spacing: 0.08em;"></div>
@@ -85,3 +85,4 @@
 </body>
 
 </html>
+


### PR DESCRIPTION
## 概要
- live 一覧の upcoming を featured 表示に変更
- フライヤーを切り抜きではなく全体表示寄りに調整
- 画像未設定時は一覧 / モーダル / detail で Coming Soon プレースホルダーを表示
- live detail でもフライヤーが綺麗に見えるように表示サイズを調整

## 確認
- node --check assets/js/site-content.js
- /live/ と /live/detail/ をローカル確認

Closes #1