### PR TITLE
liveビューのPC表示改善（フライヤー2列表示）

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -751,6 +751,24 @@ header.nav-open .nav-toggle-icon span:nth-child(3) {
   margin-top: 24px;
 }
 
+@media (min-width: 769px) {
+  .live-page #live-upcoming-events,
+  .live-page #live-past-events {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+
+  .live-page #live-upcoming-events .live-event,
+  .live-page #live-past-events .live-event {
+    height: 100%;
+  }
+
+  .live-page #live-upcoming-events .live-event.is-featured .live-flyer {
+    min-height: clamp(180px, 26vw, 260px);
+  }
+}
+
 .live-event {
   background: var(--surface);
   border: 1px solid var(--line);

--- a/live/index.html
+++ b/live/index.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="../assets/css/style.css">
 </head>
 
-<body>
+<body class="live-page">
   <!-- ヘッダー -->
   <header>
     <div class="container header-container">


### PR DESCRIPTION
## 概要
- live ページにページ限定フックを追加
- PC 幅で live 一覧を 2 列表示に変更
- スマホ幅は既存の 1 列表示を維持
- featured フライヤーの最小高さを live ページ限定で少し抑制

## 確認
- `rg -n '<body class="live-page">' live/index.html`
- `rg -n '@media \(min-width: 769px\)|live-page #live-upcoming-events|live-page #live-past-events|min-height: clamp\(180px, 26vw, 260px\)' assets/css/style.css`
- `git diff --check`

Closes #7