### PR TITLE
ticket申し込み時に申し込み内容つき自動返信を送る

### DIFF
--- a/GITHUB_WORKFLOW.md
+++ b/GITHUB_WORKFLOW.md
@@ -1,0 +1,67 @@
+# GitHub Workflow
+
+この repo の作業管理は GitHub Issue と GitHub Project を正本にする。
+
+- Repository: `1212ki/1212____HP`
+- Project: `1212hp` (`https://github.com/users/1212ki/projects/1`)
+- Account: `1212ki`
+- SSH remote: `git@github.com-new-account:1212ki/1212____HP.git`
+
+## 基本フロー
+
+1. 作業前に `git pull --ff-only` で `main` を最新化する。
+2. 既存 Issue を確認し、該当がなければ Issue を作成する。
+3. Issue を Project `1212hp` に追加し、作業中は Status を `In Progress` にする。
+4. branch は Issue 番号を含める。
+   - 例: `feature/13-ticket-autoreply`
+5. 実装後、ローカル検証と `git status` / secret 混入確認を行う。
+6. PR 作成直前に Project Status を `Review` にする。
+7. PR 本文に `Closes #XX` を入れ、Issue と PR を紐付ける。
+8. PR 作成後、Project item に linked pull request が表示されていることを確認する。
+9. merge / completion 後、Project Status を `close` にする。
+
+## Status
+
+| Status | 意味 |
+|---|---|
+| `Backlog` | 未着手候補 |
+| `Sprint` | 近く着手するもの |
+| `In Progress` | 作業中 |
+| `Review` | PR作成済み、またはレビュー待ち |
+| `close` | 完了 |
+
+## PR前チェック
+
+- Issue の完了条件を満たしている。
+- 必要なテストまたは静的検証を実行している。
+- `git status` で対象外ファイルが混ざっていない。
+- `.env`、credential、token、key、個人情報CSVを commit に含めていない。
+- PR body に `Closes #XX` を入れている。
+- Project Status を `Review` にしている。
+
+## Issue作成例
+
+```bash
+gh issue create \
+  --repo 1212ki/1212____HP \
+  --title "ticket申し込み時に申し込み内容つき自動返信を送る" \
+  --body-file issue.md \
+  --assignee @me \
+  --project "1212hp"
+```
+
+## Project Status更新例
+
+```bash
+gh project item-edit \
+  --project-id PVT_kwHOC3C5cM4BTxWk \
+  --id <PROJECT_ITEM_ID> \
+  --field-id PVTSSF_lAHOC3C5cM4BTxWkzhA9-vw \
+  --single-select-option-id <STATUS_OPTION_ID>
+```
+
+Status option ID は変更されることがあるため、更新前に確認する。
+
+```bash
+gh project field-list 1 --owner 1212ki --format json
+```

--- a/GITHUB_WORKFLOW.md
+++ b/GITHUB_WORKFLOW.md
@@ -16,9 +16,12 @@
    - 例: `feature/13-ticket-autoreply`
 5. 実装後、ローカル検証と `git status` / secret 混入確認を行う。
 6. PR 作成直前に Project Status を `Review` にする。
-7. PR 本文に `Closes #XX` を入れ、Issue と PR を紐付ける。
-8. PR 作成後、Project item に linked pull request が表示されていることを確認する。
-9. merge / completion 後、Project Status を `close` にする。
+7. PR は gate 通過後に作成する。PR 作成に個別のユーザー許可は不要。
+8. PR 本文に `Closes #XX` を入れ、Issue と PR を紐付ける。
+9. PR 作成後、Project item に linked pull request が表示されていることを確認する。
+10. merge / completion 後、Project Status を `close` にする。
+
+PR 作成はレビュー依頼の入口であり、反映そのものではない。merge は人間レビュー後に行う。
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@
 3. デプロイ
    - `wrangler deploy`
 
+## Development Workflow
+
+この repo の作業管理は GitHub Issue と GitHub Project `1212hp` で行います。
+作業前に Issue を確認または作成し、Project Status を `In Progress` にしてから branch を切ります。
+PR 作成直前は Status を `Review`、完了後は `close` にします。
+
+詳細: `GITHUB_WORKFLOW.md`
+
 ## Local Development
 
 ### 推奨（Windows / PowerShell）
@@ -93,4 +101,3 @@ python -m http.server 8888 --bind 127.0.0.1
 ## License
 
 All rights reserved. Copyright 2025 Itsuki Matsumoto.
-

--- a/admin/app.js
+++ b/admin/app.js
@@ -31,8 +31,8 @@ const DEFAULT_SITE_DATA = {
   },
   ticket: {
     introText: 'ライブを選択して、必要事項を入力してください。',
-    noticeText: '送信後、こちらからの自動返信はありません（受付の記録のみ）。',
-    completeText: '予約しました。こちらからの自動返信はありません（受付の記録のみ）。',
+    noticeText: '送信後、入力したe-mail宛に受付内容の自動返信をお送りします。',
+    completeText: '予約しました。入力したe-mail宛に受付内容の自動返信をお送りします。',
     fields: {
       showQuantity: true,
       showMessage: true,
@@ -1960,7 +1960,6 @@ window.addEventListener('beforeunload', (e) => {
     e.returnValue = '';
   }
 });
-
 
 
 

--- a/cloudflare/worker/README.md
+++ b/cloudflare/worker/README.md
@@ -51,6 +51,10 @@
        - `wrangler secret put LINE_TO`（通知先。ユーザーID/グループIDなど）
      - 方式B: 任意Webhook（Slack互換など）
        - `wrangler secret put LINE_WEBHOOK_URL`
+   - （任意）チケット予約の申込者向け自動返信
+     - `wrangler secret put TICKET_AUTOREPLY_FORM_URL`
+     - Formspreeなど、`FormData` のPOSTを受け付ける送信先URLを設定します
+     - 未設定または送信失敗時も、予約APIの成功レスポンスは妨げません
 5. デプロイ
    - `wrangler deploy`
 

--- a/cloudflare/worker/package.json
+++ b/cloudflare/worker/package.json
@@ -2,8 +2,10 @@
   "name": "itsuki-homepage-worker",
   "version": "1.0.0",
   "description": "管理画面と公開サイト向けのAPI、およびX自動投稿を担当するWorkerです。",
+  "type": "module",
   "main": "src/worker.js",
   "scripts": {
+    "test": "node --test",
     "cf:dev": "wrangler dev",
     "cf:deploy": "wrangler deploy",
     "cf:d1:migrate": "wrangler d1 execute itsuki-homepage --file=./schema.sql",

--- a/cloudflare/worker/src/worker.js
+++ b/cloudflare/worker/src/worker.js
@@ -17,8 +17,8 @@ const DEFAULT_SITE_DATA = {
   },
   ticket: {
     introText: "ライブを選択して、必要事項を入力してください。",
-    noticeText: "送信後、こちらからの自動返信はありません（受付の記録のみ）。",
-    completeText: "予約しました。こちらからの自動返信はありません（受付の記録のみ）。",
+    noticeText: "送信後、入力したe-mail宛に受付内容の自動返信をお送りします。",
+    completeText: "予約しました。入力したe-mail宛に受付内容の自動返信をお送りします。",
     fields: {
       showQuantity: true,
       showMessage: true,
@@ -1010,6 +1010,66 @@ async function notifyTicketReservation(env, reservation) {
   return results;
 }
 
+function buildTicketAutoReplyText(reservation) {
+  const r = reservation && typeof reservation === "object" ? reservation : {};
+  const live = `${String(r.liveDate || "").trim()} ${String(r.liveVenue || "").trim()}`.trim();
+  const message = String(r.message || "").trim() || "なし";
+  const lines = [
+    "ticket予約を受け付けました。",
+    "",
+    `受付ID: ${String(r.id || "").trim()}`,
+    `ライブ: ${live}`,
+    `名前: ${String(r.name || "").trim()}`,
+    `e-mail: ${String(r.email || "").trim()}`,
+    `枚数: ${String(r.quantity || "").trim()}`,
+    `備考: ${message}`,
+    "",
+    "このメールは受付内容の自動返信です。",
+  ];
+  return lines.join("\n");
+}
+
+function buildTicketAutoReplyFormData(reservation) {
+  const r = reservation && typeof reservation === "object" ? reservation : {};
+  const live = `${String(r.liveDate || "").trim()} ${String(r.liveVenue || "").trim()}`.trim();
+  const body = buildTicketAutoReplyText(r);
+  const formData = new FormData();
+  formData.set("_replyto", String(r.email || "").trim());
+  formData.set("_subject", `ticket予約受付: ${String(r.name || "").trim()}`);
+  formData.set("email", String(r.email || "").trim());
+  formData.set("name", String(r.name || "").trim());
+  formData.set("receipt_id", String(r.id || "").trim());
+  formData.set("live", live);
+  formData.set("quantity", String(r.quantity || "").trim());
+  formData.set("message", String(r.message || "").trim());
+  formData.set("body", body);
+  return formData;
+}
+
+async function sendTicketAutoReply(env, reservation) {
+  const url = String(env.TICKET_AUTOREPLY_FORM_URL || "").trim();
+  if (!url) return { skipped: true, reason: "not configured" };
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { Accept: "application/json" },
+    body: buildTicketAutoReplyFormData(reservation),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`ticket auto-reply failed: ${res.status} ${body}`.trim());
+  }
+  return { ok: true };
+}
+
+async function notifyTicketAutoReply(env, reservation) {
+  try {
+    return await sendTicketAutoReply(env, reservation);
+  } catch (e) {
+    return { ok: false, error: e.message || String(e) };
+  }
+}
+
 async function handleRequest(request, env, ctx) {
   if (request.method === "OPTIONS") {
     return new Response(null, {
@@ -1085,10 +1145,14 @@ async function handleRequest(request, env, ctx) {
     }
     try {
       const reservation = await createTicketReservation(env, payload);
+      const notifications = Promise.all([
+        notifyTicketReservation(env, reservation),
+        notifyTicketAutoReply(env, reservation),
+      ]);
       if (ctx && typeof ctx.waitUntil === "function") {
-        ctx.waitUntil(notifyTicketReservation(env, reservation));
+        ctx.waitUntil(notifications);
       } else {
-        notifyTicketReservation(env, reservation).catch(() => {});
+        notifications.catch(() => {});
       }
       return jsonResponse({ ok: true, reservation }, request, env, 201);
     } catch (error) {
@@ -1393,4 +1457,11 @@ export default {
   async scheduled(_event, env, ctx) {
     ctx.waitUntil(executeDueXPostSchedules(env));
   },
+};
+
+export {
+  buildTicketAutoReplyFormData,
+  buildTicketAutoReplyText,
+  notifyTicketAutoReply,
+  sendTicketAutoReply,
 };

--- a/cloudflare/worker/test/ticket-autoreply.test.js
+++ b/cloudflare/worker/test/ticket-autoreply.test.js
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildTicketAutoReplyFormData,
+  buildTicketAutoReplyText,
+  notifyTicketAutoReply,
+  sendTicketAutoReply,
+} from "../src/worker.js";
+
+const reservation = {
+  id: "ticket_20260502_abcd",
+  liveDate: "2026-06-01",
+  liveVenue: "下北沢Example",
+  name: "山田 太郎",
+  email: "taro@example.com",
+  quantity: 2,
+  message: "友人と行きます",
+};
+
+test("buildTicketAutoReplyText includes reservation details", () => {
+  const text = buildTicketAutoReplyText(reservation);
+
+  assert.match(text, /予約を受け付けました/);
+  assert.match(text, /受付ID: ticket_20260502_abcd/);
+  assert.match(text, /ライブ: 2026-06-01 下北沢Example/);
+  assert.match(text, /名前: 山田 太郎/);
+  assert.match(text, /e-mail: taro@example.com/);
+  assert.match(text, /枚数: 2/);
+  assert.match(text, /備考: 友人と行きます/);
+});
+
+test("buildTicketAutoReplyFormData creates Formspree-compatible payload", () => {
+  const formData = buildTicketAutoReplyFormData(reservation);
+  const entries = Object.fromEntries(formData.entries());
+
+  assert.equal(entries._replyto, "taro@example.com");
+  assert.equal(entries.email, "taro@example.com");
+  assert.equal(entries.name, "山田 太郎");
+  assert.equal(entries.receipt_id, "ticket_20260502_abcd");
+  assert.equal(entries.live, "2026-06-01 下北沢Example");
+  assert.equal(entries.quantity, "2");
+  assert.equal(entries.message, "友人と行きます");
+  assert.match(entries.body, /受付ID: ticket_20260502_abcd/);
+});
+
+test("sendTicketAutoReply skips when endpoint is not configured", async () => {
+  const originalFetch = globalThis.fetch;
+  let called = false;
+  globalThis.fetch = async () => {
+    called = true;
+    return new Response("ok");
+  };
+
+  try {
+    const result = await sendTicketAutoReply({}, reservation);
+    assert.deepEqual(result, { skipped: true, reason: "not configured" });
+    assert.equal(called, false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("sendTicketAutoReply posts the payload to the configured endpoint", async () => {
+  const originalFetch = globalThis.fetch;
+  let request = null;
+  globalThis.fetch = async (url, options) => {
+    request = { url, options };
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  };
+
+  try {
+    const result = await sendTicketAutoReply(
+      { TICKET_AUTOREPLY_FORM_URL: "https://formspree.io/f/ticket" },
+      reservation
+    );
+    const entries = Object.fromEntries(request.options.body.entries());
+
+    assert.deepEqual(result, { ok: true });
+    assert.equal(request.url, "https://formspree.io/f/ticket");
+    assert.equal(request.options.method, "POST");
+    assert.equal(request.options.headers.Accept, "application/json");
+    assert.equal(entries.email, "taro@example.com");
+    assert.match(entries.body, /ライブ: 2026-06-01 下北沢Example/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("notifyTicketAutoReply catches send failures", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response("bad request", { status: 400 });
+
+  try {
+    const result = await notifyTicketAutoReply(
+      { TICKET_AUTOREPLY_FORM_URL: "https://formspree.io/f/ticket" },
+      reservation
+    );
+    assert.equal(result.ok, false);
+    assert.match(result.error, /ticket auto-reply failed: 400/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/cloudflare/worker/wrangler.toml.example
+++ b/cloudflare/worker/wrangler.toml.example
@@ -27,5 +27,8 @@ X_DEFAULT_HASHTAGS = "#松本一樹 #ライブ"
 #
 # 方式B: 任意Webhook（Slack互換など）
 # wrangler secret put LINE_WEBHOOK_URL
+#
+# チケット予約の申込者向け自動返信（任意: FormspreeなどのPOST先）
+# wrangler secret put TICKET_AUTOREPLY_FORM_URL
 
 # 参考: X APIの予約投稿などを使う場合は、ここに crons を追加し、X系のsecretも設定する。

--- a/ticket/complete/index.html
+++ b/ticket/complete/index.html
@@ -42,7 +42,7 @@
       <div class="container">
         <h2 class="section-title">ticket</h2>
         <p id="ticket-complete-message" style="margin-top: 12px; color: var(--ink-muted);">
-          予約しました。こちらからの自動返信はありません（受付の記録のみ）。
+          予約しました。入力したe-mail宛に受付内容の自動返信をお送りします。
         </p>
 
         <div id="ticket-complete-card" style="margin-top: 18px; padding: 18px; border: 1px solid var(--line); border-radius: var(--radius-md); background: rgba(255,255,255,0.7);">

--- a/ticket/index.html
+++ b/ticket/index.html
@@ -45,7 +45,7 @@
           ライブを選択して、必要事項を入力してください。
         </p>
         <p id="ticket-notice" style="margin-top: 8px; color: var(--ink-muted);">
-          送信後、こちらからの自動返信はありません（受付の記録のみ）。
+          送信後、入力したe-mail宛に受付内容の自動返信をお送りします。
         </p>
 
         <div id="ticket-live-preview" style="margin-top: 18px;"></div>


### PR DESCRIPTION
## 概要
- ticket予約作成後に、申込者向けの受付内容自動返信を非同期送信する処理を追加
- FormspreeなどのPOST先を `TICKET_AUTOREPLY_FORM_URL` で設定できるようにし、未設定/送信失敗でも予約登録は成功扱いを維持
- 1212____HP repo内に GitHub Issue / Project 運用ルールを追加

## 検証
- npm test
- git diff --cached --check
- 古い「自動返信なし」文言が残っていないことを rg で確認

Closes #13