### PR TITLE
#10 管理画面でLiveフライヤーを保存しやすくする

### DIFF
--- a/admin/app.js
+++ b/admin/app.js
@@ -943,23 +943,67 @@ function deleteProfileLink(index) {
   markChanged();
 }
 
+const LIVE_FLYER_IMAGE_OPTIONS = {
+  downloadablePreview: true,
+  showPath: false,
+};
+
+function getImageDownloadFilename(imagePath) {
+  const cleaned = String(imagePath || '').split('#')[0].split('?')[0];
+  return cleaned.split('/').filter(Boolean).pop() || 'image';
+}
+
+function getImagePreviewHtml(inputId, previewSrc, options = {}) {
+  if (!previewSrc) {
+    return `<div class="image-placeholder" id="${inputId}-placeholder">タップして画像を選択</div>`;
+  }
+
+  const imageHtml = `<img class="image-preview-large" id="${inputId}-preview" src="${escapeHtml(previewSrc)}" alt="">`;
+  if (!options.downloadablePreview) return imageHtml;
+
+  const downloadName = options.downloadName || getImageDownloadFilename(options.imagePath || previewSrc);
+  const href = options.href || previewSrc;
+  return `<a class="image-download-link" href="${escapeHtml(href)}" download="${escapeHtml(downloadName)}" aria-label="画像を保存">${imageHtml}</a>`;
+}
+
+function renderImagePreview(inputId, previewSrc, options = {}) {
+  const container = document.getElementById(`${inputId}-preview-container`);
+  if (!container) return;
+
+  const downloadablePreview = container.dataset?.downloadablePreview === 'true';
+  container.innerHTML = getImagePreviewHtml(inputId, previewSrc, {
+    ...options,
+    downloadablePreview,
+  });
+}
+
 // 画像選択フォームHTML生成
-function getImageFormHtml(currentImage, inputId = 'edit-image') {
+function getImageFormHtml(currentImage, inputId = 'edit-image', options = {}) {
   const previewSrc = currentImage ? getImageSrc(currentImage) : '';
+  const showPath = options.showPath !== false;
+  const downloadablePreview = options.downloadablePreview === true;
+  const previewHtml = getImagePreviewHtml(inputId, previewSrc, {
+    downloadablePreview,
+    imagePath: currentImage,
+  });
+  const pathHtml = showPath
+    ? `<p class="image-path-display" id="${inputId}-path">${currentImage ? `パス: ${escapeHtml(currentImage)}` : ''}</p>`
+    : '';
+
   return `
     <div class="form-group">
       <label>画像</label>
       <div class="image-upload-area" id="image-upload-area">
         <input type="file" id="${inputId}-file" accept="image/*" onchange="handleImageSelect(this, '${inputId}')" style="display:none">
         <input type="hidden" id="${inputId}" value="${escapeHtml(currentImage || '')}">
-        <div class="image-preview-container" id="${inputId}-preview-container">
-          ${previewSrc ? `<img class="image-preview-large" id="${inputId}-preview" src="${previewSrc}" alt="">` : `<div class="image-placeholder" id="${inputId}-placeholder">タップして画像を選択</div>`}
+        <div class="image-preview-container" id="${inputId}-preview-container" data-downloadable-preview="${downloadablePreview ? 'true' : 'false'}">
+          ${previewHtml}
         </div>
         <div class="image-actions">
           <button type="button" class="btn-image-select" onclick="document.getElementById('${inputId}-file').click()">画像を選択</button>
           ${currentImage ? `<button type="button" class="btn-image-clear" onclick="clearImage('${inputId}')">削除</button>` : ''}
         </div>
-        <p class="image-path-display" id="${inputId}-path">${currentImage ? `パス: ${currentImage}` : ''}</p>
+        ${pathHtml}
       </div>
     </div>
   `;
@@ -980,7 +1024,10 @@ function handleImageSelect(input, inputId) {
 
     // プレビュー更新
     const container = document.getElementById(`${inputId}-preview-container`);
-    container.innerHTML = `<img class="image-preview-large" id="${inputId}-preview" src="${base64}" alt="">`;
+    renderImagePreview(inputId, base64, {
+      href: base64,
+      downloadName: file.name || 'image',
+    });
 
     if (!IS_API_MODE) {
       // ローカルJSON運用: ファイル名を生成（日付＋元のファイル名）
@@ -1009,6 +1056,10 @@ function handleImageSelect(input, inputId) {
       .then((result) => {
         document.getElementById(inputId).value = result.url;
         if (pathEl) pathEl.textContent = `URL: ${result.url}`;
+        renderImagePreview(inputId, base64, {
+          href: result.url,
+          imagePath: result.url,
+        });
         setImagePathForInputId(inputId, result.url);
         markChanged();
       })
@@ -1055,7 +1106,8 @@ function clearImage(inputId) {
   document.getElementById(inputId).value = '';
   const container = document.getElementById(`${inputId}-preview-container`);
   container.innerHTML = `<div class="image-placeholder" id="${inputId}-placeholder">タップして画像を選択</div>`;
-  document.getElementById(`${inputId}-path`).textContent = '';
+  const pathEl = document.getElementById(`${inputId}-path`);
+  if (pathEl) pathEl.textContent = '';
 
   // クリアボタンを削除
   const clearBtn = container.parentElement.querySelector('.btn-image-clear');
@@ -1157,7 +1209,7 @@ function addLive() {
       <label>詳細</label>
       <textarea id="edit-description" class="textarea" rows="3">open/start &#10;adv/door &#10;w.</textarea>
     </div>
-    ${getImageFormHtml('')}
+    ${getImageFormHtml('', 'edit-image', LIVE_FLYER_IMAGE_OPTIONS)}
     <div class="form-group">
       <label>リンクURL</label>
       <input type="url" id="edit-link" class="text-input" placeholder="https://...">
@@ -1212,7 +1264,7 @@ function editLive(id, category) {
       <label>詳細</label>
       <textarea id="edit-description" class="textarea" rows="3">${escapeHtml(item.description)}</textarea>
     </div>
-    ${getImageFormHtml(item.image)}
+    ${getImageFormHtml(item.image, 'edit-image', LIVE_FLYER_IMAGE_OPTIONS)}
     <div class="form-group">
       <label>詳細リンクURL（instagramなど/任意）</label>
       <input type="url" id="edit-link" class="text-input" value="${escapeHtml(item.link)}">
@@ -1960,10 +2012,6 @@ window.addEventListener('beforeunload', (e) => {
     e.returnValue = '';
   }
 });
-
-
-
-
 
 
 

--- a/admin/style.css
+++ b/admin/style.css
@@ -817,6 +817,24 @@ body {
   object-fit: contain;
 }
 
+.image-download-link {
+  display: inline-flex;
+  justify-content: center;
+  max-width: 100%;
+  border-radius: var(--radius-sm);
+  color: inherit;
+  line-height: 0;
+}
+
+.image-download-link:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 4px;
+}
+
+.image-download-link .image-preview-large {
+  display: block;
+}
+
 .image-placeholder {
   padding: 40px 20px;
   text-align: center;

--- a/cloudflare/worker/package-lock.json
+++ b/cloudflare/worker/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "worker",
+  "name": "itsuki-homepage-worker",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "worker",
+      "name": "itsuki-homepage-worker",
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {

--- a/test/admin-image-form.test.mjs
+++ b/test/admin-image-form.test.mjs
@@ -1,0 +1,228 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+
+const repoRoot = process.cwd();
+const appJs = readFileSync(join(repoRoot, 'admin/app.js'), 'utf8');
+
+function createElement(id) {
+  return {
+    id,
+    children: [],
+    dataset: {},
+    value: '',
+    checked: false,
+    textContent: '',
+    innerHTML: '',
+    parentElement: null,
+    style: {},
+    classList: {
+      add() {},
+      remove() {},
+    },
+    addEventListener() {},
+    appendChild(child) {
+      this.children.push(child);
+    },
+    querySelector() {
+      return null;
+    },
+  };
+}
+
+function loadAdminApp() {
+  const elements = new Map();
+  const missingElements = new Set();
+  class MockFileReader {
+    readAsDataURL() {
+      this.onload?.({ target: { result: 'data:image/png;base64,TEST_IMAGE' } });
+    }
+  }
+
+  const document = {
+    body: {
+      style: {},
+      appendChild() {},
+      removeChild() {},
+    },
+    addEventListener() {},
+    createElement(tag) {
+      return createElement(tag);
+    },
+    getElementById(id) {
+      if (missingElements.has(id)) return null;
+      if (!elements.has(id)) elements.set(id, createElement(id));
+      return elements.get(id);
+    },
+  };
+
+  const context = {
+    Blob,
+    FormData,
+    Headers,
+    URL,
+    URLSearchParams,
+    clearTimeout,
+    confirm: () => false,
+    console,
+    document,
+    FileReader: MockFileReader,
+    location: { hostname: 'localhost' },
+    localStorage: {
+      getItem: () => '',
+      removeItem() {},
+      setItem() {},
+    },
+    prompt: () => '',
+    setTimeout,
+    structuredClone,
+    window: {
+      ADMIN_CONFIG: {},
+      ADMIN_BUILD_ID: '',
+      addEventListener() {},
+      location: { href: 'https://1212hp.com/admin/', origin: 'https://1212hp.com' },
+      open: () => null,
+    },
+  };
+  context.globalThis = context;
+
+  vm.runInNewContext(
+    `${appJs}
+globalThis.__adminTest = {
+  addLive,
+  editLive,
+  getImageFormHtml,
+  handleImageSelect,
+  setApiMode(value) { IS_API_MODE = value; },
+  setSiteData(value) { siteData = value; },
+  setUploadImageToApi(fn) { uploadImageToApi = fn; },
+};`,
+    context,
+  );
+
+  return {
+    ...context.__adminTest,
+    elements,
+    markMissing(id) {
+      missingElements.add(id);
+    },
+  };
+}
+
+function setupImageSelectionDom(elements, inputId = 'edit-image', options = {}) {
+  const container = elements.get(`${inputId}-preview-container`) || createElement(`${inputId}-preview-container`);
+  elements.set(`${inputId}-preview-container`, container);
+  container.dataset.downloadablePreview = options.downloadablePreview ? 'true' : 'false';
+
+  const actions = createElement('image-actions');
+  actions.querySelector = () => null;
+  container.parentElement = {
+    querySelector(selector) {
+      return selector === '.image-actions' ? actions : null;
+    },
+  };
+
+  elements.set(inputId, elements.get(inputId) || createElement(inputId));
+
+  return { actions, container };
+}
+
+test('default image forms keep the existing path display for non-live images', () => {
+  const { getImageFormHtml } = loadAdminApp();
+
+  const html = getImageFormHtml('assets/images/news.jpg');
+
+  assert.match(html, /class="image-path-display"/);
+  assert.match(html, /パス: assets\/images\/news\.jpg/);
+  assert.doesNotMatch(html, /class="image-download-link"/);
+});
+
+test('default image path display escapes the current image path', () => {
+  const { getImageFormHtml } = loadAdminApp();
+
+  const html = getImageFormHtml('assets/images/flyer"><img src=x onerror=alert(1)>.jpg');
+
+  assert.match(html, /パス: assets\/images\/flyer&quot;&gt;&lt;img src=x onerror=alert\(1\)&gt;\.jpg/);
+  assert.doesNotMatch(html, /パス: .*<img src=x onerror=alert\(1\)>/);
+});
+
+test('downloadable live flyer forms hide path text and wrap the preview in a download link', () => {
+  const { getImageFormHtml } = loadAdminApp();
+
+  const html = getImageFormHtml('assets/images/flyer.jpg', 'edit-image', {
+    downloadablePreview: true,
+    showPath: false,
+  });
+
+  assert.doesNotMatch(html, /class="image-path-display"/);
+  assert.doesNotMatch(html, /パス:/);
+  assert.doesNotMatch(html, /URL:/);
+  assert.match(html, /class="image-download-link"/);
+  assert.match(html, /href="\.\.\/assets\/images\/flyer\.jpg"/);
+  assert.match(html, /download="flyer\.jpg"/);
+});
+
+test('Live edit modal uses a downloadable flyer preview without path or URL display', () => {
+  const { editLive, elements, setSiteData } = loadAdminApp();
+  setSiteData({
+    live: {
+      upcoming: [
+        {
+          id: 'live-1',
+          date: '2026.05.02',
+          title: 'test live',
+          venue: 'test venue',
+          description: 'open/start',
+          image: 'assets/images/flyer.jpg',
+          link: '',
+        },
+      ],
+      past: [],
+    },
+  });
+
+  editLive('live-1', 'upcoming');
+  const html = elements.get('modal-body').innerHTML;
+
+  assert.match(html, /class="image-download-link"/);
+  assert.match(html, /href="\.\.\/assets\/images\/flyer\.jpg"/);
+  assert.doesNotMatch(html, /class="image-path-display"/);
+  assert.doesNotMatch(html, /パス:/);
+  assert.doesNotMatch(html, /URL:/);
+});
+
+test('Live image selection keeps the selected flyer preview inside a download link', () => {
+  const { elements, handleImageSelect, markMissing } = loadAdminApp();
+  const { container } = setupImageSelectionDom(elements, 'edit-image', { downloadablePreview: true });
+  markMissing('edit-image-path');
+
+  handleImageSelect({ files: [{ name: 'new flyer.png' }] }, 'edit-image');
+
+  assert.match(container.innerHTML, /class="image-download-link"/);
+  assert.match(container.innerHTML, /href="data:image\/png;base64,TEST_IMAGE"/);
+  assert.match(container.innerHTML, /download="new flyer\.png"/);
+});
+
+test('Live API upload updates the flyer download link to the uploaded URL', async () => {
+  const {
+    elements,
+    handleImageSelect,
+    markMissing,
+    setApiMode,
+    setUploadImageToApi,
+  } = loadAdminApp();
+  const { container } = setupImageSelectionDom(elements, 'edit-image', { downloadablePreview: true });
+  markMissing('edit-image-path');
+  setApiMode(true);
+  setUploadImageToApi(async () => ({ url: 'https://cdn.example.com/live/flyer-final.png?token=1' }));
+
+  handleImageSelect({ files: [{ name: 'draft flyer.png' }] }, 'edit-image');
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.match(container.innerHTML, /class="image-download-link"/);
+  assert.match(container.innerHTML, /href="https:\/\/cdn\.example\.com\/live\/flyer-final\.png\?token=1"/);
+  assert.match(container.innerHTML, /download="flyer-final\.png"/);
+});


### PR DESCRIPTION
## Summary
- Live の管理画面フライヤープレビューを download 付きリンクにして、長押し/保存しやすくしました。
- Live フライヤー欄ではノイズになっていた パス/URL 表示を非表示にしました。
- 非 Live の画像フォームは既存のパス表示を維持しつつ、表示値を HTML escape するようにしました。

## Tests
- node --test
- node --check admin/app.js
- git diff --check

Closes #10